### PR TITLE
Convert methods to use const generic length

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Smart LED Effects
 
 This supplies a collection of effects for usage with individually addressable LED strips such as the WS2812b.
-Each effect returns a vector of colours that can then be sent to your LED driver.
+Each effect returns an array of colours that can then be sent to your LED driver.
 
 The EffectIterator trait defines two methods:
     - `name`
@@ -52,7 +52,7 @@ use smart_led_effects::{
 //...
 
     const COUNT: usize = 55;
-    let effect = strip::Rainbow::new(COUNT, None);
+    let effect = strip::Rainbow::<COUNT>::new(None);
 
     loop {
         let pixels = effect.next().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,56 +1,5 @@
-//! A library that generates effects for use with addressable LEDs.
-//! Currently it only implements 1 dimensional effects for use with a single strip of LEDs.
-//!
-//! # Usage
-//!
-//! Each effect is implemented as an iterator that returns a vector of [Srgb] colours.
-//! The vector returned is the same length as the number of LEDs in the strip (supplied when instantiating the effect).
-//! This vector can then be passed to the LED strip driver.
-//!
-//! The [strip::EffectIterator] trait is implemented for each effect, so they can be used as iterators. The iterators will currently all loop forever.
-//!
-//! # Effects
-//! | Name | Description |
-//! | ---- | ----------- |
-//! | [strip::Bounce] | The bounce effect will generate a number of balls that bounce up and down the strip |
-//! | [strip::Breathe] | The breathe effect will generate a single colour that fades in and out |
-//! | [strip::Christmas] | (WIP) Has a green background with random red, blue and gold sparkles |
-//! | [strip::Collision] | Generates two particles that can collide and bounce or shatter |
-//! | [strip::Cycle] | Rotates around the HSV colour space |
-//! | [strip::Cylon] | Generates the cylon eye effect |
-//! | [strip::Fire] | Generates an effect like a flickering flame |
-//! | [strip::Meteor] | Generates a meteor that goes down the strip trailing bits of fading debris |
-//! | [strip::Morse] | Converts a string into a series of dots and dashes as per Morse code formatting |
-//! | [strip::ProgressBar] | (WIP) Signals progress
-//! | [strip::Rainbow] | Generates a rainbow effect |
-//! | [strip::RunningLights] | Generates a running lights effect |
-//! | [strip::SnowSparkle] | Generates random sparkles |
-//! | [strip::Strobe] | Strobe light/blinder effect |
-//! | [strip::Timer] | Counts down for the given duration |
-//! | [strip::Twinkle] | Generates random twinkles |
-//! | [strip::Wipe] | Generates a wipe effect |
-//!
-//!
-//! # Example
-//!
-//! ```rust
-//! use smart_led_effects::{
-//!     strip::{self, EffectIterator},
-//!     Srgb,
-//! };
-//!
-//!
-//! const COUNT: usize = 55;
-//! let effect = strip::Rainbow::new(COUNT, None);
-//!
-//! {
-//! let pixels = effect.next().unwrap();
-//!    
-//! // show pixels
-//!
-//! thread::sleep(Duration::from_millis(10));
-//! }
-//!
+#![doc = include_str!("../README.md")]
+
 pub mod strip;
 mod utils;
 pub use palette::Srgb;

--- a/src/strip/bounce.rs
+++ b/src/strip/bounce.rs
@@ -133,14 +133,12 @@ impl Ball {
 /// - `gravity` - The gravity of the balls. If None, the default value will be used.
 /// - `bounciness` - The bounciness of the balls. If None, the default range will be used.
 /// - `speed` - The speed range of the balls. If None, the default range will be used.
-pub struct Bounce {
-    count: usize,
+pub struct Bounce<const N: usize> {
     balls: Vec<Ball>,
 }
 
-impl Bounce {
+impl<const N: usize> Bounce<N> {
     pub fn new(
-        count: usize,
         colour: Option<Srgb>,
         balls: Option<usize>,
         gravity: Option<f32>,
@@ -157,18 +155,17 @@ impl Bounce {
             ));
         }
         Bounce {
-            count,
             balls: new_balls,
         }
     }
 }
 
-impl EffectIterator for Bounce {
+impl<const N: usize> EffectIterator<N> for Bounce<N> {
     fn name(&self) -> &'static str {
         "Bounce"
     }
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
-        let mut out = vec![Srgb::<u8>::new(0, 0, 0); self.count];
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
+        let mut out = [Srgb::<u8>::new(0, 0, 0); N];
         for ball in self.balls.iter_mut() {
             ball.update();
             let pixel = ball.location();
@@ -181,13 +178,13 @@ impl EffectIterator for Bounce {
                     Direction::Up => ball.location() as i32 - i,
                     Direction::Down => ball.location() as i32 + i,
                 };
-                if pixel < self.count as i32 && pixel >= 0 {
+                if pixel < N as i32 && pixel >= 0 {
                     let mut colour: Srgb = ball.colour.into_format();
                     colour = colour.darken_fixed(i as f32 / tail_len as f32);
                     out[pixel as usize] = colour.into_format::<u8>();
                 }
             }
-            if pixel < self.count {
+            if pixel < N {
                 out[pixel] = ball.colour.into_format::<u8>();
             }
         }

--- a/src/strip/breathe.rs
+++ b/src/strip/breathe.rs
@@ -6,17 +6,16 @@ enum Direction {
     Up,
     Down,
 }
-pub struct Breathe {
+pub struct Breathe<const N: usize> {
     colour: Hsv,
     random_colour: bool,
     direction: Direction,
-    count: usize,
     step: f32,
 }
 
-impl Breathe {
+impl<const N: usize> Breathe<N> {
     const DEFAULT_STEP: f32 = 0.02;
-    pub fn new(count: usize, colour: Option<Srgb>, step_size: Option<f32>) -> Self {
+    pub fn new(colour: Option<Srgb>, step_size: Option<f32>) -> Self {
         let random_colour = colour.is_none();
         let colour: Hsv = match colour {
             Some(colour) => colour.into_color(),
@@ -27,7 +26,6 @@ impl Breathe {
             colour,
             random_colour,
             direction: Direction::Up,
-            count,
             step: step_size.unwrap_or(Self::DEFAULT_STEP),
         };
         me.set_colour();
@@ -43,12 +41,12 @@ impl Breathe {
     }
 }
 
-impl EffectIterator for Breathe {
+impl<const N: usize> EffectIterator<N> for Breathe<N> {
     fn name(&self) -> &'static str {
         "Breathe"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         match self.direction {
             Direction::Up => {
                 self.colour.value += self.step;
@@ -65,9 +63,6 @@ impl EffectIterator for Breathe {
             }
         };
 
-        Some(vec![
-            Srgb::from_color(self.colour).into_format::<u8>();
-            self.count
-        ])
+        Some([Srgb::from_color(self.colour).into_format::<u8>(); N])
     }
 }

--- a/src/strip/christmas.rs
+++ b/src/strip/christmas.rs
@@ -10,15 +10,14 @@ pub struct Sparkle {
     location: usize,
 }
 
-pub struct Christmas {
+pub struct Christmas<const N: usize> {
     frequency: u8,
     probability: f32,
     fade: f32,
     sparkles: Vec<Sparkle>,
-    length: usize,
 }
 
-impl Christmas {
+impl<const N: usize> Christmas<N> {
     const DEFAULT_FREQUENCY: u8 = 0x04;
     const DEFAULT_PROBABILITY: f32 = 0.1;
     const DEFAULT_FADE: f32 = 0.4;
@@ -26,7 +25,6 @@ impl Christmas {
     const BACKGROUND: Srgb = Srgb::new(6.0 / 255.0, 108.0 / 255.0, 22.0 / 255.0);
 
     pub fn new(
-        count: usize,
         colour: Option<Srgb<u8>>,
         sparkle: Option<u8>,
         probability: Option<f32>,
@@ -44,12 +42,11 @@ impl Christmas {
             fade: fade.unwrap_or(Christmas::DEFAULT_FADE),
             probability: probability.unwrap_or(Christmas::DEFAULT_PROBABILITY),
             sparkles: Vec::new(),
-            length: count,
         }
     }
 }
 
-impl Christmas {
+impl<const N: usize> Christmas<N> {
     fn generate_sparkle(&mut self) {
         let mut rng = thread_rng();
 
@@ -58,7 +55,7 @@ impl Christmas {
             return;
         }
 
-        let index = rng.gen_range(0..self.length);
+        let index = rng.gen_range(0..N);
 
         let c_index = rng.gen_range(0.0..1.0);
 
@@ -86,12 +83,12 @@ impl Christmas {
     }
 }
 
-impl EffectIterator for Christmas {
+impl<const N: usize> EffectIterator<N> for Christmas<N> {
     fn name(&self) -> &'static str {
         "Christmas"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         self.fade_sparkles();
 
         let chances = thread_rng().gen_range(0..self.frequency);
@@ -99,12 +96,12 @@ impl EffectIterator for Christmas {
             self.generate_sparkle();
         }
 
-        let mut out: Vec<Srgb> = vec![self::Christmas::BACKGROUND; self.length];
+        let mut out: [Srgb<u8>; N] = [self::Christmas::BACKGROUND.into_format(); N];
 
         for sparkle in self.sparkles.iter() {
             out[sparkle.location].mix_assign(sparkle.colour, sparkle.intensity);
         }
 
-        Some(out.iter().map(|&c| c.into_format::<u8>()).collect())
+        Some(out)
     }
 }

--- a/src/strip/collision.rs
+++ b/src/strip/collision.rs
@@ -42,31 +42,29 @@ impl Particle {
     }
 }
 
-pub struct Collision {
+pub struct Collision<const N: usize> {
     particles: Vec<Particle>,
-    count: usize,
     shatter: bool,
     shattered: bool,
-    current: Vec<Srgb>,
+    current: [Srgb; N],
 }
 
-impl Collision {
-    pub fn new(count: usize, shatter: Option<bool>) -> Self {
+impl<const N: usize> Collision<N> {
+    pub fn new(shatter: Option<bool>) -> Self {
         let p1 = Particle::new(0, false);
-        let p2 = Particle::new(count as i32, true);
+        let p2 = Particle::new(N as i32, true);
 
         Collision {
-            count,
             particles: vec![p1, p2],
             shatter: shatter.unwrap_or(true),
             shattered: false,
-            current: vec![Srgb::new(0.0, 0.0, 0.0); count],
+            current: [Srgb::new(0.0, 0.0, 0.0); N],
         }
     }
 
     pub fn reset(&mut self) {
         let p1 = Particle::new(0, false);
-        let p2 = Particle::new(self.count as i32 - 1, true);
+        let p2 = Particle::new(N as i32 - 1, true);
 
         self.particles = vec![p1, p2];
         self.shattered = false;
@@ -89,21 +87,21 @@ impl Collision {
         }
         self.shattered = true;
 
-        self.current[self.count / 2] = Srgb::new(1.0, 1.0, 1.0);
+        self.current[N / 2] = Srgb::new(1.0, 1.0, 1.0);
 
         let mut hsv = Hsv::from_color(self.particles[0].colour);
         hsv.value = 1.0;
-        let normalize = 1.0 / self.count as f32;
+        let normalize = 1.0 / N as f32;
 
         let mut rng = thread_rng();
 
-        for i in 0..(self.count / 2) {
+        for i in 0..(N / 2) {
             if rng.gen_range(0.0..1.0) < 0.5 {
                 let hsv = hsv.darken(1.0 - normalize * i as f32);
                 self.current[i] = Srgb::from_color(hsv);
             }
         }
-        for i in (self.count / 2)..(self.count) {
+        for i in (N / 2)..(N) {
             if rng.gen_range(0.0..1.0) < 0.5 {
                 let hsv = hsv.darken(normalize * i as f32);
                 self.current[i] = Srgb::from_color(hsv);
@@ -111,20 +109,20 @@ impl Collision {
         }
     }
 
-    pub fn move_particles(&mut self) -> Vec<Srgb<u8>> {
-        let mut out = vec![Srgb::<u8>::new(0, 0, 0); self.count];
+    pub fn move_particles(&mut self) -> [Srgb<u8>; N] {
+        let mut out = [Srgb::<u8>::new(0, 0, 0); N];
         for particle in self.particles.iter_mut() {
-            if particle.position >= 0 && particle.position < self.count as i32 {
+            if particle.position >= 0 && particle.position < N as i32 {
                 for i in 0..particle.size {
                     if particle.reverse {
                         if particle.position + i as i32 >= 0
-                            && i as i32 + particle.position < self.count as i32
+                            && i as i32 + particle.position < N as i32
                         {
                             out[(particle.position + i as i32) as usize] =
                                 particle.colour.into_format();
                         }
                     } else if particle.position - i as i32 >= 0
-                        && (particle.position - i as i32) < self.count as i32
+                        && (particle.position - i as i32) < N as i32
                     {
                         out[(particle.position - i as i32) as usize] =
                             particle.colour.into_format();
@@ -137,12 +135,12 @@ impl Collision {
     }
 }
 
-impl EffectIterator for Collision {
+impl<const N: usize> EffectIterator<N> for Collision<N> {
     fn name(&self) -> &'static str {
         "Collision"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         if !self.shattered {
             for particle in self.particles.iter_mut() {
                 if particle.reverse {
@@ -156,7 +154,7 @@ impl EffectIterator for Collision {
                 self.shatter();
             }
 
-            if self.particles[0].position < 0 && self.particles[1].position >= self.count as i32 {
+            if self.particles[0].position < 0 && self.particles[1].position >= N as i32 {
                 self.reset();
             }
 
@@ -177,7 +175,7 @@ impl EffectIterator for Collision {
                 }
             }
             self.reset();
-            Some(vec![Srgb::<u8>::new(0, 0, 0); self.count])
+            Some([Srgb::<u8>::new(0, 0, 0); N])
         }
     }
 }

--- a/src/strip/cycle.rs
+++ b/src/strip/cycle.rs
@@ -1,15 +1,15 @@
 use crate::strip::EffectIterator;
 use palette::{FromColor, Hsv, ShiftHue, Srgb};
 
-pub struct Cycle {
+pub struct Cycle<const N: usize> {
     last_state: Vec<Hsv>,
     step_size: f32,
 }
 
-impl Cycle {
-    pub fn new(count: usize, steps: Option<usize>) -> Self {
+impl<const N: usize> Cycle<N> {
+    pub fn new(steps: Option<usize>) -> Self {
         let color = Hsv::new(0.0, 1.0, 1.0);
-        let last_state = vec![color; count];
+        let last_state = vec![color; N];
 
         let step = steps.unwrap_or(360);
         let step_size = 360.0 / step as f32;
@@ -21,19 +21,23 @@ impl Cycle {
     }
 }
 
-impl EffectIterator for Cycle {
+impl<const N: usize> EffectIterator<N> for Cycle<N> {
     fn name(&self) -> &'static str {
         "Cycle"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         if let Some(pixel) = self.last_state.first() {
             self.last_state = vec![pixel.shift_hue(self.step_size); self.last_state.len()];
             Some(
                 self.last_state
                     .iter()
                     .map(|x| Srgb::from_color(*x).into_format::<u8>())
-                    .collect::<Vec<Srgb<u8>>>(),
+                    .collect::<Vec<Srgb<u8>>>()
+                    .try_into()
+                    .unwrap_or_else(|v: Vec<Srgb<u8>>| {
+                        panic!("Expected a Vec of length {} but it was {}", N, v.len())
+                    }),
             )
         } else {
             None

--- a/src/strip/cylon.rs
+++ b/src/strip/cylon.rs
@@ -18,7 +18,7 @@ impl Direction {
     }
 }
 
-pub struct Cylon {
+pub struct Cylon<const N: usize> {
     colour: Hsv,
     direction: Direction,
     brightness: Vec<f32>,
@@ -27,12 +27,12 @@ pub struct Cylon {
     fade: f32,
 }
 
-impl Cylon {
+impl<const N: usize> Cylon<N> {
     const DEFAULT_SIZE: usize = 4;
     const DEFAULT_FADE: f32 = 0.2;
 
-    pub fn new(count: usize, colour: Srgb<u8>, size: Option<usize>, fade: Option<f32>) -> Self {
-        let mut brightness = vec![0.0; count];
+    pub fn new(colour: Srgb<u8>, size: Option<usize>, fade: Option<f32>) -> Self {
+        let mut brightness = vec![0.0; N];
         let size = size.unwrap_or(Cylon::DEFAULT_SIZE);
 
         for pixel in brightness.iter_mut().take(size) {
@@ -50,12 +50,12 @@ impl Cylon {
     }
 }
 
-impl EffectIterator for Cylon {
+impl<const N: usize> EffectIterator<N> for Cylon<N> {
     fn name(&self) -> &'static str {
         "Cylon"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         let len = self.brightness.len();
 
         let mut trail: Vec<f32> = vec![0.0; len];
@@ -94,7 +94,7 @@ impl EffectIterator for Cylon {
             }
         };
 
-        let out: Vec<Srgb<u8>> = self
+        let out: [Srgb<u8>; N] = self
             .brightness
             .iter()
             .zip(trail.iter())
@@ -103,7 +103,11 @@ impl EffectIterator for Cylon {
                 pixel.value = (x + y).min(1.0);
                 Srgb::from_color(pixel).into_format::<u8>()
             })
-            .collect();
+            .collect::<Vec<Srgb<u8>>>()
+            .try_into()
+            .unwrap_or_else(|v: Vec<Srgb<u8>>| {
+                panic!("Expected a Vec of length {} but it was {}", N, v.len())
+            });
 
         Some(out)
     }

--- a/src/strip/effects_trait.rs
+++ b/src/strip/effects_trait.rs
@@ -1,6 +1,6 @@
 use palette::Srgb;
 
-pub trait EffectIterator {
+pub trait EffectIterator<const N: usize> {
     fn name(&self) -> &'static str;
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>>;
+    fn next(&mut self) -> Option<[Srgb<u8>; N]>;
 }

--- a/src/strip/fire.rs
+++ b/src/strip/fire.rs
@@ -2,26 +2,26 @@ use crate::strip::EffectIterator;
 use palette::Srgb;
 use rand::{thread_rng, Rng};
 
-pub struct Fire {
+pub struct Fire<const N: usize> {
     cooling: u8,
     sparking: u8,
-    heat: Vec<u8>,
+    heat: [u8; N],
 }
 
-impl Fire {
+impl<const N: usize> Fire<N> {
     const DEFAULT_COOLING: u8 = 40;
     const DEFAULT_SPARKING: u8 = 120;
-    pub fn new(count: usize, cooling: Option<u8>, sparking: Option<u8>) -> Self {
+    pub fn new(cooling: Option<u8>, sparking: Option<u8>) -> Self {
         Fire {
-            cooling: (((cooling.unwrap_or(Fire::DEFAULT_COOLING) as f32 * 10.0) / count as f32)
+            cooling: (((cooling.unwrap_or(Fire::DEFAULT_COOLING) as f32 * 10.0) / N as f32)
                 + 2.0) as u8,
             sparking: sparking.unwrap_or(Fire::DEFAULT_SPARKING),
-            heat: vec![0; count],
+            heat: [0; N],
         }
     }
 }
 
-impl Fire {
+impl<const N: usize> Fire<N> {
     fn heat_to_colour(val: u8) -> Srgb<u8> {
         if val >= 0x85 {
             let heat_ramp = 3u8.saturating_mul(val - 0x85);
@@ -36,12 +36,12 @@ impl Fire {
     }
 }
 
-impl EffectIterator for Fire {
+impl<const N: usize> EffectIterator<N> for Fire<N> {
     fn name(&self) -> &'static str {
         "Fire"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         let mut rng = thread_rng();
 
         /* apply cooling */
@@ -64,11 +64,10 @@ impl EffectIterator for Fire {
             self.heat[y] = self.heat[y].saturating_add(rng.gen_range(160..255));
         }
 
-        Some(
-            self.heat
-                .iter()
-                .map(|x| Fire::heat_to_colour(*x))
-                .collect::<Vec<Srgb<u8>>>(),
-        )
+        let mut out = [Srgb::<u8>::new(0, 0, 0); N];
+        for (i, &heat) in self.heat.iter().enumerate() {
+            out[i] = Fire::heat_to_colour(heat);
+        }
+        Some(out)
     }
 }

--- a/src/strip/meteor.rs
+++ b/src/strip/meteor.rs
@@ -1,45 +1,43 @@
 use crate::strip::EffectIterator;
 use palette::{Darken, Srgb};
 use rand::{thread_rng, Rng};
-pub struct Meteor {
-    count: usize,
+
+pub struct Meteor<const N: usize> {
     colour: Srgb,
     size: usize,
     position: usize,
     fade: f32,
-    current: Vec<Srgb>,
+    current: [Srgb; N],
     random_colour: bool,
 }
 
-impl Meteor {
+impl<const N: usize> Meteor<N> {
     const DEFAULT_SIZE: usize = 4;
     const DEFAULT_FADE: f32 = 0.3;
     const DEFAULT_COLOUR: Srgb<u8> = Srgb::<u8>::new(255, 255, 255);
 
     pub fn new(
-        count: usize,
         colour: Option<Srgb<u8>>,
         size: Option<usize>,
         fade: Option<f32>,
     ) -> Self {
         Meteor {
-            count,
             colour: colour.unwrap_or(Self::DEFAULT_COLOUR).into_format(),
             size: size.unwrap_or(Self::DEFAULT_SIZE),
             position: 0,
             fade: fade.unwrap_or(Self::DEFAULT_FADE),
-            current: vec![Srgb::new(0.0, 0.0, 0.0); count],
+            current: [Srgb::new(0.0, 0.0, 0.0); N],
             random_colour: colour.is_none(),
         }
     }
 }
 
-impl EffectIterator for Meteor {
+impl<const N: usize> EffectIterator<N> for Meteor<N> {
     fn name(&self) -> &'static str {
         "Meteor"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         let mut rng = thread_rng();
         for pixel in self.current.iter_mut() {
             if rng.gen_range(0.0..1.0) < 0.5 {
@@ -48,12 +46,12 @@ impl EffectIterator for Meteor {
         }
 
         for i in 0..self.size {
-            if (self.position.saturating_sub(i) < self.count) && (self.position >= i) {
+            if (self.position.saturating_sub(i) < N) && (self.position >= i) {
                 self.current[self.position - i] = self.colour;
             }
         }
         self.position += 1;
-        if self.position > 2 * self.count {
+        if self.position > 2 * N {
             if self.random_colour {
                 self.colour = Srgb::new(
                     rng.gen_range(0.0..1.0),
@@ -64,6 +62,6 @@ impl EffectIterator for Meteor {
             self.position = 0;
         }
 
-        Some(self.current.iter().map(|p| p.into_format()).collect())
+        Some(self.current)
     }
 }

--- a/src/strip/mod.rs
+++ b/src/strip/mod.rs
@@ -59,42 +59,40 @@ pub fn list() -> Vec<String> {
     LIST.iter().map(|s| s.to_string()).collect()
 }
 
-pub fn get_default_effect(count: usize, name: &str) -> Option<Box<dyn EffectIterator>> {
+pub fn get_default_effect<const N: usize>(name: &str) -> Option<Box<dyn EffectIterator<N>>> {
     match name {
-        "Breathe" => Some(Box::new(Breathe::new(count, None, None))),
-        "Bounce" => Some(Box::new(Bounce::new(count, None, None, None, None, None))),
-        "Collision" => Some(Box::new(Collision::new(count, Some(true)))),
-        "Cycle" => Some(Box::new(Cycle::new(count, None))),
+        "Breathe" => Some(Box::new(Breathe::new(None, None))),
+        "Bounce" => Some(Box::new(Bounce::new(None, None, None, None, None))),
+        "Collision" => Some(Box::new(Collision::new(Some(true)))),
+        "Cycle" => Some(Box::new(Cycle::new(None))),
         "Cylon" => Some(Box::new(Cylon::new(
-            count,
             palette::Srgb::<u8>::new(255, 0, 0),
             None,
             None,
         ))),
-        "Fire" => Some(Box::new(Fire::new(count, None, None))),
-        "Meteor" => Some(Box::new(Meteor::new(count, None, None, None))),
-        "Morse" => Some(Box::new(Morse::new(count, "Hello, world!", None, false))),
-        "ProgressBar" => Some(Box::new(ProgressBar::new(count, None, None, None))),
-        "Rainbow" => Some(Box::new(Rainbow::new(count, None))),
-        "RunningLights" => Some(Box::new(RunningLights::new(count, None, false))),
+        "Fire" => Some(Box::new(Fire::new(None, None))),
+        "Meteor" => Some(Box::new(Meteor::new(None, None, None))),
+        "Morse" => Some(Box::new(Morse::new("Hello, world!", None, false))),
+        "ProgressBar" => Some(Box::new(ProgressBar::new(None, None, None))),
+        "Rainbow" => Some(Box::new(Rainbow::new(None))),
+        "RunningLights" => Some(Box::new(RunningLights::new(None, false))),
         "Strobe" => Some(Box::new(Strobe::new(
-            count,
             None,
             std::time::Duration::from_secs(1),
             None,
         ))),
-        // "Timer" => Some(Box::new(Timer::new(count, None, None))),
-        "Twinkle" => Some(Box::new(Twinkle::new(count, None, None, None, None))),
-        "SnowSparkle" => Some(Box::new(SnowSparkle::new(count, None, None, None, None))),
-        "Wipe" => Some(Box::new(Wipe::colour_wipe(count, None, false))),
+        // "Timer" => Some(Box::new(Timer::new(None, None))),
+        "Twinkle" => Some(Box::new(Twinkle::new(None, None, None, None))),
+        "SnowSparkle" => Some(Box::new(SnowSparkle::new(None, None, None, None))),
+        "Wipe" => Some(Box::new(Wipe::colour_wipe(None, false))),
         _ => None,
     }
 }
 
-pub fn get_all_default_effects(count: usize) -> Vec<Box<dyn EffectIterator>> {
+pub fn get_all_default_effects<const N: usize>() -> Vec<Box<dyn EffectIterator<N>>> {
     let mut effects = Vec::new();
     for name in LIST {
-        if let Some(effect) = get_default_effect(count, name) {
+        if let Some(effect) = get_default_effect::<N>(name) {
             effects.push(effect);
         }
     }

--- a/src/strip/morse.rs
+++ b/src/strip/morse.rs
@@ -1,12 +1,12 @@
 use crate::strip::{EffectIterator, Wipe};
 use palette::Srgb;
 
-pub struct Morse {
-    wipe: Wipe,
+pub struct Morse<const N: usize> {
+    wipe: Wipe<N>,
 }
 
-impl Morse {
-    pub fn new(count: usize, message: &str, colour: Option<Srgb<u8>>, reverse: bool) -> Self {
+impl<const N: usize> Morse<N> {
+    pub fn new(message: &str, colour: Option<Srgb<u8>>, reverse: bool) -> Self {
         let code = Self::string_to_morse(message);
 
         let colour = colour.unwrap_or(Srgb::new(255, 0, 0));
@@ -16,7 +16,7 @@ impl Morse {
             .map(|&x| if x == 1 { colour } else { Srgb::new(0, 0, 0) })
             .collect::<Vec<Srgb<u8>>>();
 
-        let wipe = Wipe::new(count, code, reverse);
+        let wipe = Wipe::new(code, reverse);
 
         Morse { wipe }
     }
@@ -71,12 +71,12 @@ impl Morse {
     }
 }
 
-impl EffectIterator for Morse {
+impl<const N: usize> EffectIterator<N> for Morse<N> {
     fn name(&self) -> &'static str {
         "Morse"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         self.wipe.next()
     }
 }

--- a/src/strip/progress.rs
+++ b/src/strip/progress.rs
@@ -1,32 +1,29 @@
 use crate::strip::EffectIterator;
 use palette::{Mix, Srgb};
 
-pub struct ProgressBar {
-    count: usize,
+pub struct ProgressBar<const N: usize> {
     start_colour: Srgb,
     end_colour: Srgb,
     gradient: bool,
     pixels_per_percent: f32,
     current_value: f32,
     last_value: f32,
-    last_pixels: Option<Vec<Srgb<u8>>>,
+    last_pixels: Option<[Srgb<u8>; N]>,
 }
 
-impl ProgressBar {
+impl<const N: usize> ProgressBar<N> {
     const DEFAULT_START_COLOUR: Srgb = Srgb::new(0.0, 0.0, 1.0);
     const DEFAULT_END_COLOUR: Srgb = Srgb::new(1.0, 0.0, 0.0);
     pub fn new(
-        count: usize,
         start_colour: Option<Srgb>,
         end_colour: Option<Srgb>,
         gradient: Option<bool>,
     ) -> Self {
         ProgressBar {
-            count,
             start_colour: start_colour.unwrap_or(Self::DEFAULT_START_COLOUR),
             end_colour: end_colour.unwrap_or(Self::DEFAULT_END_COLOUR),
             gradient: gradient.unwrap_or(false),
-            pixels_per_percent: count as f32 / 100.0,
+            pixels_per_percent: N as f32 / 100.0,
             current_value: 0.0,
             last_value: 0.0,
             last_pixels: None,
@@ -37,16 +34,16 @@ impl ProgressBar {
         self.current_value = percentage;
     }
 
-    pub fn get_output_for_value(&mut self, percentage: f32) -> Vec<Srgb<u8>> {
+    pub fn get_output_for_value(&mut self, percentage: f32) -> [Srgb<u8>; N] {
         let percentage = percentage.clamp(0.0, 100.0);
-        let pixels = self.count - (self.pixels_per_percent * (100.0 - percentage)) as usize;
-        let mut out = vec![Srgb::new(0.0, 0.0, 0.0).into_format(); self.count];
+        let pixels = N - (self.pixels_per_percent * (100.0 - percentage)) as usize;
+        let mut out = [Srgb::new(0.0, 0.0, 0.0).into_format(); N];
 
         if self.gradient {
             for (i, pixel) in out.iter_mut().take(pixels).enumerate() {
                 *pixel = self
                     .start_colour
-                    .mix(self.end_colour, i as f32 / self.count as f32)
+                    .mix(self.end_colour, i as f32 / N as f32)
                     .into_format();
             }
         } else {
@@ -62,12 +59,12 @@ impl ProgressBar {
     }
 }
 
-impl EffectIterator for ProgressBar {
+impl<const N: usize> EffectIterator<N> for ProgressBar<N> {
     fn name(&self) -> &'static str {
         "ProgressBar"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         if self.current_value == self.last_value {
             if let Some(pixels) = self.last_pixels.take() {
                 return Some(pixels);

--- a/src/strip/rainbow.rs
+++ b/src/strip/rainbow.rs
@@ -1,23 +1,20 @@
 use crate::strip::EffectIterator;
 use palette::{FromColor, Hsv, ShiftHueAssign, Srgb};
 
-pub struct Rainbow {
-    last_state: Vec<Hsv>,
+pub struct Rainbow<const N: usize> {
+    last_state: [Hsv; N],
     step_size: f32,
 }
 
-impl Rainbow {
-    pub fn new(count: usize, steps: Option<usize>) -> Self {
-        let mut last_state = Vec::new();
-        let mut color = Hsv::new(0.0, 1.0, 1.0);
-        last_state.push(color);
-        let separation = 360.0 / count as f32;
+impl<const N: usize> Rainbow<N> {
+    pub fn new(steps: Option<usize>) -> Self {
+        let mut last_state = [Hsv::new(0.0, 1.0, 1.0); N];
+        let separation = 360.0 / N as f32;
         let step = steps.unwrap_or(360);
         let step_size = 360.0 / step as f32;
 
-        for _ in 1..count {
-            color.shift_hue_assign(separation);
-            last_state.push(color);
+        for i in 1..N {
+            last_state[i].shift_hue_assign(separation);
         }
         Rainbow {
             last_state,
@@ -26,12 +23,12 @@ impl Rainbow {
     }
 }
 
-impl EffectIterator for Rainbow {
+impl<const N: usize> EffectIterator<N> for Rainbow<N> {
     fn name(&self) -> &'static str {
         "Rainbow"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         for pixel in self.last_state.iter_mut() {
             pixel.shift_hue_assign(self.step_size);
         }
@@ -40,7 +37,11 @@ impl EffectIterator for Rainbow {
             self.last_state
                 .iter()
                 .map(|x| Srgb::from_color(*x).into_format::<u8>())
-                .collect::<Vec<Srgb<u8>>>(),
+                .collect::<Vec<Srgb<u8>>>()
+                .try_into()
+                .unwrap_or_else(|v: Vec<Srgb<u8>>| {
+                    panic!("Expected a Vec of length {} but it was {}", N, v.len())
+                }),
         )
     }
 }

--- a/src/strip/running_lights.rs
+++ b/src/strip/running_lights.rs
@@ -1,23 +1,22 @@
 use crate::strip::EffectIterator;
 use crate::utils::{single_hsv_to_srgb, srgbu8_to_hsv};
 use palette::{Hsv, Srgb};
-pub struct RunningLights {
+
+pub struct RunningLights<const N: usize> {
     colour: Hsv,
-    count: usize,
     position: usize,
     reverse: bool,
 }
 
-impl RunningLights {
-    pub fn new(count: usize, colour: Option<Srgb<u8>>, reverse: bool) -> Self {
+impl<const N: usize> RunningLights<N> {
+    pub fn new(colour: Option<Srgb<u8>>, reverse: bool) -> Self {
         RunningLights {
             colour: match colour {
                 Some(colour) => srgbu8_to_hsv(colour),
                 None => Hsv::new(0.0, 0.0, 1.0),
             },
-            count,
             position: match reverse {
-                true => count,
+                true => N,
                 false => 0,
             },
             reverse,
@@ -25,13 +24,13 @@ impl RunningLights {
     }
 }
 
-impl EffectIterator for RunningLights {
+impl<const N: usize> EffectIterator<N> for RunningLights<N> {
     fn name(&self) -> &'static str {
         "RunningLights"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
-        let mut out = vec![Srgb::<u8>::new(0, 0, 0); self.count];
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
+        let mut out = [Srgb::<u8>::new(0, 0, 0); N];
         for (i, pixel) in out.iter_mut().enumerate() {
             let brightness = (i as f32 + self.position as f32).sin() / 2.0 + 0.5;
             let mut hsv = self.colour;
@@ -41,11 +40,11 @@ impl EffectIterator for RunningLights {
         if self.reverse {
             self.position -= 1;
             if self.position == 0 {
-                self.position = self.count;
+                self.position = N;
             }
         } else {
             self.position += 1;
-            if self.position >= self.count {
+            if self.position >= N {
                 self.position = 0;
             }
         }

--- a/src/strip/snow_sparkle.rs
+++ b/src/strip/snow_sparkle.rs
@@ -4,21 +4,20 @@ use rand::{thread_rng, Rng};
 
 use crate::utils::{hsv_to_srgb, srgbu8_to_hsv};
 
-pub struct SnowSparkle {
+pub struct SnowSparkle<const N: usize> {
     frequency: u8,
     probability: f32,
     fade: f32,
     colour: Hsv,
-    current: Vec<Hsv>,
+    current: [Hsv; N],
 }
 
-impl SnowSparkle {
+impl<const N: usize> SnowSparkle<N> {
     const DEFAULT_FREQUENCY: u8 = 0x04;
     const DEFAULT_PROBABILITY: f32 = 0.1;
     const DEFAULT_FADE: f32 = 0.4;
     const BASE_BRIGHTNESS: f32 = 0.2;
     pub fn new(
-        count: usize,
         colour: Option<Srgb<u8>>,
         sparkle: Option<u8>,
         probability: Option<f32>,
@@ -35,21 +34,21 @@ impl SnowSparkle {
             frequency: sparkle.unwrap_or(SnowSparkle::DEFAULT_FREQUENCY),
             fade: fade.unwrap_or(SnowSparkle::DEFAULT_FADE),
             probability: probability.unwrap_or(SnowSparkle::DEFAULT_PROBABILITY),
-            current: vec![colour; count],
+            current: [colour; N],
             colour,
         }
     }
 
-    pub fn sparkle(count: usize, colour: Option<Srgb<u8>>) -> Self {
+    pub fn sparkle(colour: Option<Srgb<u8>>) -> Self {
         let colour = match colour {
             Some(colour) => Some(colour),
             None => Some(Srgb::<u8>::new(255, 255, 255)),
         };
-        SnowSparkle::new(count, colour, Some(20), Some(0.4), Some(1.0))
+        SnowSparkle::new(colour, Some(20), Some(0.4), Some(1.0))
     }
 }
 
-impl SnowSparkle {
+impl<const N: usize> SnowSparkle<N> {
     fn generate_sparkle(&mut self) {
         let mut rng = thread_rng();
         let index = rng.gen_range(0..self.current.len());
@@ -70,12 +69,12 @@ impl SnowSparkle {
     }
 }
 
-impl EffectIterator for SnowSparkle {
+impl<const N: usize> EffectIterator<N> for SnowSparkle<N> {
     fn name(&self) -> &'static str {
         "SnowSparkle"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         self.fade_sparkles();
 
         let chances = thread_rng().gen_range(0..self.frequency);

--- a/src/strip/strobe.rs
+++ b/src/strip/strobe.rs
@@ -29,8 +29,7 @@ use super::EffectIterator;
 /// let mut effect = Strobe::new(count, colour, period, decay);
 /// ```
 #[derive(Debug)]
-pub struct Strobe {
-    count: usize,
+pub struct Strobe<const N: usize> {
     colour: Option<Hsv>,
     current_colour: Hsv,
     period: Duration,
@@ -38,9 +37,8 @@ pub struct Strobe {
     start: Instant,
 }
 
-impl Strobe {
+impl<const N: usize> Strobe<N> {
     pub fn new(
-        count: usize,
         colour: Option<Srgb<u8>>,
         period: Duration,
         decay: Option<f32>,
@@ -52,7 +50,6 @@ impl Strobe {
         };
 
         Strobe {
-            count,
             colour,
             current_colour,
             period,
@@ -86,19 +83,19 @@ impl Strobe {
     }
 }
 
-impl EffectIterator for Strobe {
+impl<const N: usize> EffectIterator<N> for Strobe<N> {
     fn name(&self) -> &'static str {
         "Strobe"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         if self.fade() {
             let elapsed = self.start.elapsed().as_secs();
             if elapsed >= self.period.as_secs() {
                 self.reset();
             }
         }
-        let out = vec![Srgb::from_color(self.current_colour).into_format::<u8>(); self.count];
+        let out = [Srgb::from_color(self.current_colour).into_format::<u8>(); N];
         Some(out)
     }
 }

--- a/src/strip/timer.rs
+++ b/src/strip/timer.rs
@@ -2,8 +2,7 @@ use crate::strip::EffectIterator;
 use palette::{Mix, Srgb};
 use std::time::{Duration, Instant};
 
-pub struct Timer {
-    count: usize,
+pub struct Timer<const N: usize> {
     duration: Duration,
     start_colour: Srgb,
     end_colour: Srgb,
@@ -13,11 +12,10 @@ pub struct Timer {
     running: bool,
 }
 
-impl Timer {
+impl<const N: usize> Timer<N> {
     const DEFAULT_START_COLOUR: Srgb = Srgb::new(0.0, 0.0, 1.0);
     const DEFAULT_END_COLOUR: Srgb = Srgb::new(1.0, 0.0, 0.0);
     pub fn new(
-        count: usize,
         duration: Duration,
         start_colour: Option<Srgb>,
         end_colour: Option<Srgb>,
@@ -25,12 +23,11 @@ impl Timer {
         start: bool,
     ) -> Self {
         Timer {
-            count,
             duration,
             start_colour: start_colour.unwrap_or(Self::DEFAULT_START_COLOUR),
             end_colour: end_colour.unwrap_or(Self::DEFAULT_END_COLOUR),
             gradient: gradient.unwrap_or(false),
-            pixels_per_second: (count as f32) / (duration.as_millis() as f32 / 1000.0),
+            pixels_per_second: (N as f32) / (duration.as_millis() as f32 / 1000.0),
             start: Instant::now(),
             running: start,
         }
@@ -50,24 +47,24 @@ impl Timer {
     }
 }
 
-impl EffectIterator for Timer {
+impl<const N: usize> EffectIterator<N> for Timer<N> {
     fn name(&self) -> &'static str {
         "Timer"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
-        let mut out = vec![Srgb::new(0u8, 0u8, 0u8); self.count];
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
+        let mut out = [Srgb::new(0u8, 0u8, 0u8); N];
         let elapsed = self.start.elapsed().as_secs();
         if elapsed >= self.duration.as_secs() {
             self.reset();
             return Some(out);
         }
-        let pixels = self.count - (self.pixels_per_second * elapsed as f32).ceil() as usize;
+        let pixels = N - (self.pixels_per_second * elapsed as f32).ceil() as usize;
         if self.gradient {
             for (i, pixel) in out.iter_mut().take(pixels).enumerate() {
                 *pixel = self
                     .end_colour
-                    .mix(self.start_colour, i as f32 / self.count as f32)
+                    .mix(self.start_colour, i as f32 / N as f32)
                     .into_format();
             }
         } else {

--- a/src/strip/twinkle.rs
+++ b/src/strip/twinkle.rs
@@ -4,20 +4,19 @@ use rand::{thread_rng, Rng};
 
 use crate::utils::hsv_to_srgb;
 
-pub struct Twinkle {
+pub struct Twinkle<const N: usize> {
     frequency: u8,
     probability: f32,
     fade: f32,
     colour: Option<Hsv>,
-    current: Vec<Hsv>,
+    current: [Hsv; N],
 }
 
-impl Twinkle {
+impl<const N: usize> Twinkle<N> {
     const DEFAULT_FREQUENCY: u8 = 0x04;
     const DEFAULT_PROBABILITY: f32 = 0.1;
     const DEFAULT_FADE: f32 = 0.02;
     pub fn new(
-        count: usize,
         colour: Option<Srgb<u8>>,
         sparkle: Option<u8>,
         probability: Option<f32>,
@@ -27,21 +26,21 @@ impl Twinkle {
             frequency: sparkle.unwrap_or(Twinkle::DEFAULT_FREQUENCY),
             fade: fade.unwrap_or(Twinkle::DEFAULT_FADE),
             probability: probability.unwrap_or(Twinkle::DEFAULT_PROBABILITY),
-            current: vec![Hsv::new(0.0, 1.0, 0.0); count],
+            current: [Hsv::new(0.0, 1.0, 0.0); N],
             colour: colour.map(|colour| Hsv::from_color(colour.into_format())),
         }
     }
 
-    pub fn sparkle(count: usize, colour: Option<Srgb<u8>>) -> Self {
+    pub fn sparkle(colour: Option<Srgb<u8>>) -> Self {
         let colour = match colour {
             Some(colour) => Some(colour),
             None => Some(Srgb::<u8>::new(255, 255, 255)),
         };
-        Twinkle::new(count, colour, Some(20), Some(0.4), Some(1.0))
+        Twinkle::new(colour, Some(20), Some(0.4), Some(1.0))
     }
 }
 
-impl Twinkle {
+impl<const N: usize> Twinkle<N> {
     fn generate_sparkle(&mut self) {
         let mut rng = thread_rng();
         let index = rng.gen_range(0..self.current.len());
@@ -70,12 +69,12 @@ impl Twinkle {
     }
 }
 
-impl EffectIterator for Twinkle {
+impl<const N: usize> EffectIterator<N> for Twinkle<N> {
     fn name(&self) -> &'static str {
         "Twinkle"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         self.fade_sparkles();
 
         let chances = thread_rng().gen_range(0..self.frequency);

--- a/src/strip/wipe.rs
+++ b/src/strip/wipe.rs
@@ -2,22 +2,21 @@ use crate::strip::EffectIterator;
 use palette::{FromColor, Hsv, Srgb};
 use rand::Rng;
 
-pub struct Wipe {
+pub struct Wipe<const N: usize> {
     position: usize,
     buffer: Vec<Srgb<u8>>,
     reverse: bool,
     end: usize,
-    count: usize,
     randomize: bool,
 }
 
-impl Wipe {
-    pub fn new(count: usize, data: Vec<Srgb<u8>>, reverse: bool) -> Self {
-        let mut buffer = vec![Srgb::<u8>::new(0, 0, 0); count];
+impl<const N: usize> Wipe<N> {
+    pub fn new(data: Vec<Srgb<u8>>, reverse: bool) -> Self {
+        let mut buffer = vec![Srgb::<u8>::new(0, 0, 0); N];
         buffer.extend(data);
-        buffer.extend(vec![Srgb::<u8>::new(0, 0, 0); count]);
+        buffer.extend(vec![Srgb::<u8>::new(0, 0, 0); N]);
 
-        let end = buffer.len() - count;
+        let end = buffer.len() - N;
 
         Wipe {
             position: match reverse {
@@ -27,13 +26,12 @@ impl Wipe {
             buffer,
             reverse,
             end,
-            count,
             randomize: false,
         }
     }
 
-    pub fn colour_wipe(count: usize, colour: Option<Srgb<u8>>, reverse: bool) -> Self {
-        let mut s = Wipe::new(count, vec![Srgb::new(0, 0, 0); count], reverse);
+    pub fn colour_wipe(colour: Option<Srgb<u8>>, reverse: bool) -> Self {
+        let mut s = Wipe::new(vec![Srgb::new(0, 0, 0); N], reverse);
         match colour {
             Some(colour) => s.fill_wipe(colour),
             None => s.randomize_colour_wipe(),
@@ -42,9 +40,9 @@ impl Wipe {
     }
 
     fn fill_wipe(&mut self, colour: Srgb<u8>) {
-        let mut buffer = vec![Srgb::<u8>::new(0, 0, 0); self.count];
-        buffer.extend(vec![colour; self.count]);
-        buffer.extend(vec![Srgb::<u8>::new(0, 0, 0); self.count]);
+        let mut buffer = vec![Srgb::<u8>::new(0, 0, 0); N];
+        buffer.extend(vec![colour; N]);
+        buffer.extend(vec![Srgb::<u8>::new(0, 0, 0); N]);
         self.buffer = buffer;
     }
 
@@ -57,19 +55,23 @@ impl Wipe {
     }
 }
 
-impl EffectIterator for Wipe {
+impl<const N: usize> EffectIterator<N> for Wipe<N> {
     fn name(&self) -> &'static str {
         "Wipe"
     }
 
-    fn next(&mut self) -> Option<Vec<Srgb<u8>>> {
+    fn next(&mut self) -> Option<[Srgb<u8>; N]> {
         let out = self
             .buffer
             .iter()
             .skip(self.position)
-            .take(self.count)
+            .take(N)
             .copied()
-            .collect::<Vec<Srgb<u8>>>();
+            .collect::<Vec<Srgb<u8>>>()
+            .try_into()
+            .unwrap_or_else(|v: Vec<Srgb<u8>>| {
+                panic!("Expected a Vec of length {} but it was {}", N, v.len())
+            });
 
         if self.reverse {
             self.position -= 1;


### PR DESCRIPTION
Convert methods to use const generic length instead of length argument and return arrays instead of vectors.

* Modify `Bounce`, `Breathe`, `Christmas`, `Collision`, `Cycle`, `Cylon`, `Fire`, `Meteor`, `Morse`, `ProgressBar`, `Rainbow`, `RunningLights`, `SnowSparkle`, `Strobe`, `Timer`, `Twinkle`, and `Wipe` structs to use const generic length.
* Update `EffectIterator` trait to use const generic length and return arrays.
* Update `get_default_effect` and `get_all_default_effects` functions to use const generic length.
* Update example in `src/lib.rs` to use const generic length.
* Update `README.md` to mention const generic length.

